### PR TITLE
node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,5 +11,5 @@ inputs:
   babashka-url:
     description: 'The babashka/babashka url to make available on the path. Useful for CI builds. Example https://16810-201467090-gh.circle-artifacts.com/0/release/babashka-0.3.3-SNAPSHOT-linux-amd64.tar.gz When using "babashka-url" the parameter "babashka-version" is still required, to allow for appropriate caching between runs. Example: babashka-version: 0.3.3-SNAPSHOT'
 runs:
-  using: 'node18'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Using node18 fails at the moment

```
Current runner version: '2.301.1'
Operating System
Runner Image
Runner Image Provisioner
GITHUB_TOKEN Permissions
Secret source: Actions
Prepare workflow directory
Prepare all required actions
Getting action download info
Download action repository 'turtlequeue/setup-babashka@main' (SHA:3b713486fa[2](https://github.com/turtlequeue/setup-babashka/actions/runs/4025462177/jobs/6918705935#step:1:2)f78e3884a0887[6](https://github.com/turtlequeue/setup-babashka/actions/runs/4025462177/jobs/6918705935#step:1:7)f[29](https://github.com/turtlequeue/setup-babashka/actions/runs/4025462177/jobs/6918705935#step:1:33)c1c50d1eb079)
Error: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter ''using: node18' is not supported, use 'docker', 'node12' or 'node16' instead.')
   at GitHub.Runner.Worker.ActionManifestManager.ConvertRuns(IExecutionContext executionContext, TemplateContext templateContext, TemplateToken inputsToken, String fileRelativePath, MappingToken outputs)
   at GitHub.Runner.Worker.ActionManifestManager.Load(IExecutionContext executionContext, String manifestFile)
Error: Fail to load turtlequeue/setup-babashka/main/action.yml
```