### PR TITLE
Updating to use Node.js v20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,5 +11,5 @@ inputs:
   babashka-url:
     description: 'The babashka/babashka url to make available on the path. Useful for CI builds. Example https://16810-201467090-gh.circle-artifacts.com/0/release/babashka-0.3.3-SNAPSHOT-linux-amd64.tar.gz When using "babashka-url" the parameter "babashka-version" is still required, to allow for appropriate caching between runs. Example: babashka-version: 0.3.3-SNAPSHOT'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-babashka",
-  "version": "1.3.0",
+  "version": "1.6.0",
   "private": false,
   "description": "setup babashka action",
   "main": "src/setup-babashka.ts",
@@ -33,7 +33,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@types/node": "^18.0.0",
+    "@types/node": "^20.0.0",
     "@types/semver": "^7.3.10",
     "@types/uuid": "^8.3.0",
     "@vercel/ncc": "^0.34.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -100,10 +100,12 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/node@^18.0.0":
-  version "18.0.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.0.tgz#67c7b724e1bcdd7a8821ce0d5ee184d3b4dd525a"
-  integrity sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==
+"@types/node@^20.0.0":
+  version "20.11.28"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.28.tgz#4fd5b2daff2e580c12316e457473d68f15ee6f66"
+  integrity sha512-M/GPWVS2wLkSkNHVeLkrF2fD5Lx5UC4PxA0uZcKc6QqbIQUJyW1jVjueJYi1z8n0I5PxYrtpnPnWglE+y9A0KA==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/semver@^7.3.10":
   version "7.3.10"
@@ -1590,6 +1592,11 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
Seems like node 16 is deprecated since 2023-09-11: https://nodejs.org/en/blog/announcements/nodejs16-eol
Updating to keep up to date and get rid of warnings in workflows using this action.

Hoping we could bump versions and create a new release, thanks! 🙏🏼